### PR TITLE
feat: optimize named imports; code split

### DIFF
--- a/src/getNiceTickValues.js
+++ b/src/getNiceTickValues.js
@@ -7,7 +7,7 @@ import Decimal from 'decimal.js-light';
 import {
   compose, range, memoize, map, reverse,
 } from './util/utils';
-import Arithmetic from './util/arithmetic';
+import { getDigitCount, rangeStep } from './util/arithmetic';
 
 /**
  * Calculate a interval of a minimum value and a maximum value
@@ -39,7 +39,7 @@ function getValidInterval([min, max]) {
 function getFormatStep(roughStep, allowDecimals, correctionFactor) {
   if (roughStep.lte(0)) { return new Decimal(0); }
 
-  const digitCount = Arithmetic.getDigitCount(roughStep.toNumber());
+  const digitCount = getDigitCount(roughStep.toNumber());
   // The ratio between the rough step and the smallest number which has a bigger
   // order of magnitudes than the rough step
   const digitCountValue = new Decimal(10).pow(digitCount);
@@ -73,7 +73,7 @@ function getTickOfSingleValue(value, tickCount, allowDecimals) {
 
     if (absVal < 1) {
       // The step should be a float number when the difference is smaller than 1
-      step = new Decimal(10).pow(Arithmetic.getDigitCount(value) - 1);
+      step = new Decimal(10).pow(getDigitCount(value) - 1);
 
       middle = new Decimal(Math.floor(middle.div(step).toNumber())).mul(step);
     } else if (absVal > 1) {
@@ -184,7 +184,7 @@ function getNiceTickValuesFn([min, max], tickCount = 6, allowDecimals = true) {
   // Get the step between two ticks
   const { step, tickMin, tickMax } = calculateStep(cormin, cormax, count, allowDecimals);
 
-  const values = Arithmetic.rangeStep(tickMin, tickMax.add(new Decimal(0.1).mul(step)), step);
+  const values = rangeStep(tickMin, tickMax.add(new Decimal(0.1).mul(step)), step);
 
   return min > max ? reverse(values) : values;
 }
@@ -244,7 +244,7 @@ function getTickValuesFixedDomainFn([min, max], tickCount, allowDecimals = true)
   const count = Math.max(tickCount, 2);
   const step = getFormatStep(new Decimal(cormax).sub(cormin).div(count - 1), allowDecimals, 0);
   const values = [
-    ...Arithmetic.rangeStep(
+    ...rangeStep(
       new Decimal(cormin),
       new Decimal(cormax).sub(new Decimal(0.99).mul(step)),
       step,

--- a/src/util/arithmetic.js
+++ b/src/util/arithmetic.js
@@ -15,7 +15,7 @@ import { curry } from './utils';
  * @param  {Number} value 数值
  * @return {Integer} 位数
  */
-function getDigitCount(value) {
+export function getDigitCount(value) {
   let result;
 
   if (value === 0) {
@@ -37,7 +37,7 @@ function getDigitCount(value) {
  * @param  {Decimal} step  步长
  * @return {Array}         若干数值
  */
-function rangeStep(start, end, step) {
+export function rangeStep(start, end, step) {
   let num = new Decimal(start);
   let i = 0;
   const result = [];
@@ -60,7 +60,7 @@ function rangeStep(start, end, step) {
  * @param  {Number} t  [0, 1]内的某个值
  * @return {Number}    定义域内的某个值
  */
-const interpolateNumber = curry((a, b, t) => {
+export const interpolateNumber = curry((a, b, t) => {
   const newA = +a;
   const newB = +b;
 
@@ -74,7 +74,7 @@ const interpolateNumber = curry((a, b, t) => {
  * @param  {Number} x 可以认为是插值后的一个输出值
  * @return {Number}   当x在 a ~ b这个范围内时，返回值属于[0, 1]
  */
-const uninterpolateNumber = curry((a, b, x) => {
+export const uninterpolateNumber = curry((a, b, x) => {
   let diff = b - (+a);
 
   diff = diff || Infinity;
@@ -90,7 +90,7 @@ const uninterpolateNumber = curry((a, b, x) => {
  * @return {Number}   当x在 a ~ b这个区间内时，返回值属于[0, 1]，
  * 当x不在 a ~ b这个区间时，会截断到 a ~ b 这个区间
  */
-const uninterpolateTruncation = curry((a, b, x) => {
+export const uninterpolateTruncation = curry((a, b, x) => {
   let diff = b - (+a);
 
   diff = diff || Infinity;

--- a/test/util/arithmetic.test.js
+++ b/test/util/arithmetic.test.js
@@ -1,9 +1,9 @@
 import test from 'ava';
-import Arithmetic from '../../src/util/arithmetic';
+import { rangeStep, getDigitCount } from '../../src/util/arithmetic';
 // rangeStep
 test('of integer step', (t) => {
   const [start, end, step] = [14, 20, 3];
-  const result = Arithmetic.rangeStep(start, end, step);
+  const result = rangeStep(start, end, step);
 
   t.deepEqual(result, [14, 17]);
 });
@@ -11,7 +11,7 @@ test('of integer step', (t) => {
 // of float step
 test('should return right step of float start', (t) => {
   const [start, end, step] = [0.1, 0.85, 0.1];
-  const result = Arithmetic.rangeStep(start, end, step);
+  const result = rangeStep(start, end, step);
 
   t.deepEqual(result, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]);
 });
@@ -19,7 +19,7 @@ test('should return right step of float start', (t) => {
 // of float step
 test('should return right step of small float start', (t) => {
   const [start, end, step] = [0, 0.0000035000000000000004, 3.5000000000000004e-7];
-  const result = Arithmetic.rangeStep(start, end, step);
+  const result = rangeStep(start, end, step);
 
   t.deepEqual(result, [
     0,
@@ -37,19 +37,19 @@ test('should return right step of small float start', (t) => {
 
 test('should return right step of integer start', (t) => {
   const [start, end, step] = [1, 2, 0.1];
-  const result = Arithmetic.rangeStep(start, end, step);
+  const result = rangeStep(start, end, step);
 
   t.deepEqual(result, [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9]);
 });
 
 // getDigitCount
 test('should return count of digit', (t) => {
-  t.deepEqual(Arithmetic.getDigitCount(1289), 4);
-  t.deepEqual(Arithmetic.getDigitCount(0.0912), -1);
-  t.deepEqual(Arithmetic.getDigitCount(0), 1);
-  t.deepEqual(Arithmetic.getDigitCount(1.1e+21), 22);
-  t.deepEqual(Arithmetic.getDigitCount(1.1e-21), -20);
-  t.deepEqual(Arithmetic.getDigitCount(12345.67), 5);
-  t.deepEqual(Arithmetic.getDigitCount(-12345.67), 5);
-  t.deepEqual(Arithmetic.getDigitCount(-0.0000007), -6);
+  t.deepEqual(getDigitCount(1289), 4);
+  t.deepEqual(getDigitCount(0.0912), -1);
+  t.deepEqual(getDigitCount(0), 1);
+  t.deepEqual(getDigitCount(1.1e+21), 22);
+  t.deepEqual(getDigitCount(1.1e-21), -20);
+  t.deepEqual(getDigitCount(12345.67), 5);
+  t.deepEqual(getDigitCount(-12345.67), 5);
+  t.deepEqual(getDigitCount(-0.0000007), -6);
 });


### PR DESCRIPTION
Named imports help bundlers cut unused code (will be good with https://github.com/recharts/recharts-scale/pull/36)

Profit: less bytes at client side

Tip: it is back capability changes. Needs a patch.